### PR TITLE
Search: fixing some display bugs

### DIFF
--- a/_assets/css/algolia.css
+++ b/_assets/css/algolia.css
@@ -194,7 +194,7 @@
   border: 1px solid #ccc;
   border-top: none;
   border-radius: 3px;
-  z-Index: 100;
+  z-Index: 2000;
   position: absolute; }
 
 .hit_title {

--- a/_assets/css/style.css
+++ b/_assets/css/style.css
@@ -513,7 +513,7 @@ Sticky nav
 	position: fixed !important;
     top: 0;
     left: 0;
-    z-index: 1000;
+    z-index: 3000;
     width: 100%;
     max-width: 100%;
 	background:#fff;

--- a/_assets/js/search.js
+++ b/_assets/js/search.js
@@ -1,6 +1,22 @@
-function toggle_display(node_id) {
+// detects if the user has scrolled down
+function _user_has_scrolled_down() {
+  return $(window).scrollTop() > 0;
+}
+
+// toggles the display of node
+// returns true if the node is displayed after function call
+function _toggle_display(node_id, force_display) {
   const element = document.getElementById(node_id);
-  element.style.display = (element.style.display === 'none' ? '' : 'none');
+  const is_not_displayed = element.style.display === 'none';
+  const to_be_displayed = is_not_displayed || force_display;
+  element.style.display = (to_be_displayed ? '' : 'none');
+  return to_be_displayed;
+}
+
+// displays the node (if needed) and scrolls to it
+function toggle_display(node_id) {
+  if (_toggle_display(node_id, _user_has_scrolled_down()))
+    $('html,body').animate({scrollTop: 0}, 500);
 }
 
 (function start_search_engine() {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -76,7 +76,7 @@
                         </li>
 
                         <li>
-                          <a onclick="toggle_display('searchpanel');">Recherche</a>
+                            <a href="#" onclick="toggle_display('searchpanel');">Recherche</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
- search results under the map (welcome page)
- mouse pointer for "Recherche" hover
- smouth sroll to top when clicking "Recherche"
- don't hide search panel if it was displayed but not visible on "Recherche" click